### PR TITLE
Fix the fact that two rust toolchains are installed during the installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -84,8 +84,11 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Setting up source files..." --weight=3
 
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
-# Download, check integrity, uncompress and patch the source from app.src
+
+# Download, check integrity, uncompress the source of bitwarden_rs from app.src to his build directory
 ynh_setup_source --dest_dir="$final_path/build/" --source_id=app
+
+# Download, check integrity, uncompress and patch the source from web.src
 ynh_setup_source --dest_dir="$final_path/live/web-vault/" --source_id=web
 
 #=================================================
@@ -114,19 +117,22 @@ ynh_script_progression --message="Making install..." --weight=780
 # Set right permissions 
 chown -R "$app":"$app" $final_path
 
-# Install
+# Install rustup
 pushd $final_path
     sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=nightly'
 popd
 
 export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 
 
+# Compile bitwarden_rs
 pushd $final_path/build
     sudo -u "$app" env PATH=$PATH cargo build --release
 popd
 
+# Install bitwarden_rs
 cp -a $final_path/build/target/release/. $final_path/live/.
 
+# Remove build files and rustup
 ynh_secure_remove --file="$final_path/build"
 ynh_secure_remove --file="$final_path/.cargo"
 ynh_secure_remove --file="$final_path/.rustup"

--- a/scripts/install
+++ b/scripts/install
@@ -117,9 +117,9 @@ ynh_script_progression --message="Making install..." --weight=780
 # Set right permissions 
 chown -R "$app":"$app" $final_path
 
-# Install rustup
+# Install rustup with the toolchain needed by bitwarden_rs
 pushd $final_path
-    sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=nightly'
+    sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=$(cat build/rust-toolchain)'
 popd
 
 export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -126,9 +126,9 @@ chown -R "$app":"$app" $final_path
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
-	# Install rustup
+	# Install rustup with the toolchain needed by bitwarden_rs
 	pushd $final_path
-	    sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=nightly'
+	    sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=$(cat build/rust-toolchain)'
 	popd
 
 	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -84,8 +84,10 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=6
 
-	# Download, check integrity, uncompress and patch the source from app.src
+	# Download, check integrity, uncompress the source of bitwarden_rs from app.src to his build directory
 	ynh_setup_source --dest_dir="$final_path/build/" --source_id=app
+
+	# Download, check integrity, uncompress and patch the source from web.src
 	ynh_setup_source --dest_dir="$final_path/live/web-vault/" --source_id=web
 fi
 
@@ -124,19 +126,22 @@ chown -R "$app":"$app" $final_path
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
-	# Install
+	# Install rustup
 	pushd $final_path
 	    sudo -u "$app" RUSTUP_HOME=$final_path/.rustup CARGO_HOME=$final_path/.cargo bash -c 'curl -sSf -L https://static.rust-lang.org/rustup.sh | sh -s -- -y --default-toolchain=nightly'
 	popd
 
 	export PATH="$PATH:$final_path/.cargo/bin:$final_path/.local/bin:/usr/local/sbin" 
 
+	# Compile bitwarden_rs
 	pushd $final_path/build
 	    sudo -u "$app" env PATH=$PATH cargo build --release
 	popd
 
+	# Install bitwarden_rs
 	cp -a $final_path/build/target/release/. $final_path/live/.
 
+	# Remove build files and rustup
 	ynh_secure_remove --file="$final_path/build"
 	ynh_secure_remove --file="$final_path/.cargo"
 	ynh_secure_remove --file="$final_path/.rustup"


### PR DESCRIPTION
## Problem
- *When we install the application two rust toolchain are installed, the most recent nightly and the version needed by bitwarden_rs thanks to his rust-toolchain file*

## Solution
- *Then I modified the rustup installation command to use the version of the rust-toochain file as default toolchain*

Note: I also rebase the testing branch on the master one

PS: I also add some comment, you can remove them if you want.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [X] Fix or enhancement tested.
- [X] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/bitwarden_ynh%20PR10%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/bitwarden_ynh%20PR10%20(yalh76)/)  

Revision: 0aad051f3ac30c084889b58f6002a08f08ec034c 

![image](https://user-images.githubusercontent.com/30271971/63597921-cd47be80-c5be-11e9-8166-aec2b6c00736.png)
