### PR TITLE
Fixes for package_check

### DIFF
--- a/check_process
+++ b/check_process
@@ -12,17 +12,17 @@
 		pkg_linter=1
 		setup_sub_dir=0
 		setup_root=1
-		# setup_nourl=0
-		# setup_private=1
-		# setup_public=1
-		# upgrade=1
-		# upgrade=1	from_commit=501bf18eafcda987ac255d12ca213d15e63c5eef
-		# backup_restore=1
-		# multi_instance=1
+		setup_nourl=0
+		setup_private=1
+		setup_public=1
+		upgrade=1
+		upgrade=1	from_commit=501bf18eafcda987ac255d12ca213d15e63c5eef
+		backup_restore=1
+		multi_instance=1
 		# This test is no longer necessary since the version 2.7 (PR: https://github.com/YunoHost/yunohost/pull/304), you can still do it if your app could be installed with this version.
 		# incorrect_path=1
-		# port_already_use=0
-		# change_url=0
+		port_already_use=0
+		change_url=0
 ;;; Levels
 	# If the level 5 (Package linter) is forced to 1. Please add justifications here.
 	Level 5=auto

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -15,10 +15,10 @@ ExecStart=__FINALPATH__/live/bitwarden_rs
 LimitNOFILE=1048576
 LimitNPROC=64
 # Isolate bitwarden_rs from the rest of the system
-# PrivateTmp=true
-# PrivateDevices=true
-# ProtectHome=true
-# ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=strict
 # Only allow writes to the following directory and set it to the working directory (user and password data are stored here)
 WorkingDirectory=__FINALPATH__/live/
 ReadWriteDirectories=__FINALPATH__/live/

--- a/scripts/backup
+++ b/scripts/backup
@@ -84,9 +84,6 @@ ynh_backup --src_path="/etc/systemd/system/$app.service"
 ynh_print_info --message="Starting a systemd service..."
 
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Rocket has launched from" --length=100
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
-	sleep 60
-fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -119,9 +119,6 @@ fi
 ynh_print_info --message="Starting a systemd service..."
 
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Rocket has launched from" --length=100
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
-	sleep 60
-fi
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -253,4 +253,4 @@ ynh_send_readme_to_admin --app_message="../conf/message" --recipients="$admin_ma
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info --message="Installation of $app completed" --time --last
+ynh_print_info --message="Installation of $app completed"

--- a/scripts/install
+++ b/scripts/install
@@ -161,6 +161,8 @@ ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --targ
 ynh_replace_string --match_string="__WEBSOCKET_PORT__" --replace_string="$websocket_port" --target_file="$config"
 ynh_replace_string --match_string="__ROCKET_PORT__" --replace_string="$rocket_port" --target_file="$config"
 ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
+
+# Workaround for ci-apps error starting bitwarden service 
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
 	ynh_replace_string --match_string="WEBSOCKET_ENABLED=true" --replace_string="WEBSOCKET_ENABLED=false" --target_file="$config"
 fi

--- a/scripts/install
+++ b/scripts/install
@@ -13,7 +13,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 # MANAGE SCRIPT FAILURE
 #=================================================
-ynh_script_progression --message="Managing script failure..." --time --weight=1
+ynh_print_info --message="Managing script failure..."
 
 ynh_clean_setup () {
 	ynh_clean_check_starting
@@ -24,7 +24,7 @@ ynh_abort_if_errors
 #=================================================
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
-ynh_script_progression --message="Retrieving arguments from the manifest..." --time --weight=1
+ynh_print_info --message="Retrieving arguments from the manifest..."
 
 domain=$YNH_APP_ARG_DOMAIN
 path_url="/"
@@ -39,7 +39,7 @@ admin_token=$(ynh_string_random --length=48 | base64)
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
 #=================================================
-ynh_script_progression --message="Validating installation parameters..." --time --weight=1
+ynh_print_info --message="Validating installation parameters..."
 
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
@@ -50,7 +50,7 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 #=================================================
 # STORE SETTINGS FROM MANIFEST
 #=================================================
-ynh_script_progression --message="Storing installation settings..." --time --weight=1
+ynh_print_info --message="Storing installation settings..."
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
@@ -63,7 +63,7 @@ ynh_app_setting_set --app=$app --key=admin_token --value=$admin_token
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..." --time --weight=1
+ynh_print_info --message="Configuring firewall..."
 
 # Find an available port
 websocket_port=$(ynh_find_port --port=3012)
@@ -76,14 +76,14 @@ ynh_app_setting_set --app=$app --key=rocket_port --value="$rocket_port"
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Installing dependencies..." --time --weight=1
+ynh_print_info --message="Installing dependencies..."
 
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_script_progression --message="Setting up source files..." --time --weight=1
+ynh_print_info --message="Setting up source files..."
 
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 
@@ -96,7 +96,7 @@ ynh_setup_source --dest_dir="$final_path/live/web-vault/" --source_id=web
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Configuring nginx web server..." --time --weight=1
+ynh_print_info --message="Configuring nginx web server..."
 
 # Create a dedicated nginx config
 ynh_add_nginx_config "websocket_port rocket_port"
@@ -104,7 +104,7 @@ ynh_add_nginx_config "websocket_port rocket_port"
 #=================================================
 # CREATE DEDICATED USER
 #=================================================
-ynh_script_progression --message="Configuring system user..." --time --weight=1
+ynh_print_info --message="Configuring system user..."
 
 # Create a system user
 ynh_system_user_create --username="$app" --home_dir="$final_path"
@@ -114,7 +114,7 @@ ynh_system_user_create --username="$app" --home_dir="$final_path"
 #=================================================
 # MAKE INSTALL
 #=================================================
-ynh_script_progression --message="Making install..." --time --weight=1
+ynh_print_info --message="Making install..."
 
 # Set right permissions 
 chown -R "$app":"$app" "$final_path"
@@ -142,7 +142,7 @@ ynh_secure_remove --file="$final_path/.rustup"
 #=================================================
 # SETUP SYSTEMD
 #=================================================
-ynh_script_progression --message="Configuring a systemd service..." --time --weight=1
+ynh_print_info --message="Configuring a systemd service..."
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
@@ -150,7 +150,7 @@ ynh_add_systemd_config
 #=================================================
 # MODIFY A CONFIG FILE
 #=================================================
-ynh_script_progression --message="Modifying a config file..." --time --weight=1
+ynh_print_info --message="Modifying a config file..."
 
 config="$final_path/live/bitwarden_rs.env"
 
@@ -161,11 +161,14 @@ ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --targ
 ynh_replace_string --match_string="__WEBSOCKET_PORT__" --replace_string="$websocket_port" --target_file="$config"
 ynh_replace_string --match_string="__ROCKET_PORT__" --replace_string="$rocket_port" --target_file="$config"
 ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+	ynh_replace_string --match_string="WEBSOCKET_ENABLED=true" --replace_string="WEBSOCKET_ENABLED=false" --target_file="$config"
+fi
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM
 #=================================================
-ynh_script_progression --message="Storing the config file checksum..." --time --weight=1
+ynh_print_info --message="Storing the config file checksum..."
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file="$config"
@@ -175,7 +178,7 @@ ynh_store_file_checksum --file="$config"
 #=================================================
 # SECURE FILES AND DIRECTORIES
 #=================================================
-ynh_script_progression --message="Securing files and directories..." --time --weight=1
+ynh_print_info --message="Securing files and directories..."
 
 # Set permissions to app files
 chown -R "$app":"$app" "$final_path"
@@ -185,7 +188,7 @@ chown -R "$app":"$app" "/var/log/$app"
 #=================================================
 # SETUP LOGROTATE
 #=================================================
-ynh_script_progression --message="Configuring log rotation..." --time --weight=1
+ynh_print_info --message="Configuring log rotation..."
 
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate
@@ -193,25 +196,22 @@ ynh_use_logrotate
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================
-ynh_script_progression --message="Integrating service in YunoHost..." --time --weight=1
+ynh_print_info --message="Integrating service in YunoHost..."
 
 yunohost service add $app --description "$app daemon for Bitwarden" --log "/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
-ynh_script_progression --message="Starting a systemd service..." --time --weight=1
+ynh_print_info --message="Starting a systemd service..."
 
 # Start a systemd service
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Rocket has launched from" --length=100
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
-	sleep 600
-fi
 
 #=================================================
 # SETUP FAIL2BAN
 #=================================================
-ynh_script_progression --message="Configuring fail2ban..." --time --weight=1
+ynh_print_info --message="Configuring fail2ban..."
 
 # Create a dedicated fail2ban config
 touch /var/log/"$app"/"$app".log
@@ -220,7 +220,7 @@ ynh_add_fail2ban_config --logpath="/var/log/$app/$app.log" --failregex="^.*Usern
 #=================================================
 # SETUP SSOWAT
 #=================================================
-ynh_script_progression --message="Configuring SSOwat..." --time --weight=1
+ynh_print_info --message="Configuring SSOwat..."
 
 # Make app public if necessary
 if [ $is_public -eq 1 ]
@@ -232,14 +232,14 @@ fi
 #=================================================
 # RELOAD NGINX
 #=================================================
-ynh_script_progression --message="Reloading nginx web server..." --time --weight=1
+ynh_print_info --message="Reloading nginx web server..."
 
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # SEND A README FOR THE ADMIN
 #=================================================
-ynh_script_progression --message="Sending a readme for the admin..." --time --weight=1
+ynh_print_info --message="Sending a readme for the admin..."
 
 ynh_replace_string --match_string="__ADMIN_MAIL__"    --replace_string="$admin_mail"    --target_file="../conf/message"
 ynh_replace_string --match_string="__ADMIN_TOKEN__"    --replace_string="$admin_token"    --target_file="../conf/message"
@@ -251,4 +251,4 @@ ynh_send_readme_to_admin --app_message="../conf/message" --recipients="$admin_ma
 # END OF SCRIPT
 #=================================================
 
-ynh_script_progression --message="Installation of $app completed" --time --last
+ynh_print_info --message="Installation of $app completed" --time --last

--- a/scripts/restore
+++ b/scripts/restore
@@ -120,11 +120,7 @@ yunohost service add $app --description "$app daemon for Bitwarden" --log "/var/
 #=================================================
 ynh_print_info --message="Starting a systemd service..."
 
-
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Rocket has launched from" --length=100
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
-	sleep 60
-fi
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -164,6 +164,8 @@ ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --targ
 ynh_replace_string --match_string="__WEBSOCKET_PORT__" --replace_string="$websocket_port" --target_file="$config"
 ynh_replace_string --match_string="__ROCKET_PORT__" --replace_string="$rocket_port" --target_file="$config"
 ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
+
+# Workaround for ci-apps error starting bitwarden service
 if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
 	ynh_replace_string --match_string="WEBSOCKET_ENABLED=true" --replace_string="WEBSOCKET_ENABLED=false" --target_file="$config"
 fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -164,6 +164,9 @@ ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --targ
 ynh_replace_string --match_string="__WEBSOCKET_PORT__" --replace_string="$websocket_port" --target_file="$config"
 ynh_replace_string --match_string="__ROCKET_PORT__" --replace_string="$rocket_port" --target_file="$config"
 ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
+if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+	ynh_replace_string --match_string="WEBSOCKET_ENABLED=true" --replace_string="WEBSOCKET_ENABLED=false" --target_file="$config"
+fi
 
 #=================================================
 # STORE THE CONFIG FILE CHECKSUM
@@ -227,9 +230,6 @@ fi
 ynh_print_info --message="Starting a systemd service..."
 
 ynh_systemd_action --service_name=$app --action="start" --log_path="systemd" --line_match="Rocket has launched from" --length=100
-if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
-	sleep 60
-fi
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem
- *Fix #24*
- During package_check on ci-apps, after starting bitwraden service fails with error:
```
bitwarden_rs[14488]: thread '<unnamed>' panicked at 'failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }', src/libcore/result.rs:1188:5
systemd[1]: bitwarden.service: Main process exited, code=exited, status=101/n/a
systemd[1]: bitwarden.service: Unit entered failed state.
systemd[1]: bitwarden.service: Failed with result 'exit-code'.
```

## Solution
- *Disable websocket during package_check*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/bitwarden_ynh%20PR42%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/bitwarden_ynh%20PR42%20(yalh76)/)  

Revision: 9caed2f8092c4b8fe06a64cc43d670f923ff2cb7 

![image](https://user-images.githubusercontent.com/30271971/73295242-9ded4b80-4207-11ea-94e6-80a85be2a50f.png)
 
