### PR TITLE
Use skipped_uris to be able to authenticate when user is authenticated in the SSO

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
         "name": "yalh76"
     },
     "requirements": {
-        "yunohost": ">= 3.5"
+        "yunohost": ">= 3.8.4.8"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/install
+++ b/scripts/install
@@ -224,7 +224,7 @@ ynh_print_info --message="Configuring SSOwat..."
 if [ $is_public -eq 1 ]
 then
 	# unprotected_uris allows SSO credentials to be passed anyway.
-	ynh_app_setting_set --app=$app --key=unprotected_uris --value="/"
+	ynh_app_setting_set --app=$app --key=skipped_uris --value="/"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -224,7 +224,7 @@ ynh_print_info --message="Upgrading SSOwat configuration..."
 if [ $is_public -eq 1 ]
 then
 	# unprotected_uris allows SSO credentials to be passed anyway
-	ynh_app_setting_set --app=$app --key=unprotected_uris --value="/"
+	ynh_app_setting_set --app=$app --key=skipped_uris --value="/"
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

https://github.com/YunoHost-Apps/bitwarden_ynh/issues/3

## Solution

Fix this issue in public case

Note that PR need https://github.com/YunoHost/yunohost/pull/1005 to work well.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/bitwraden_ynh_ynh%20(josue)/1/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/bitwraden_ynh_ynh%20(josue)/1/)  
